### PR TITLE
Install multiple desktop files to handle ubuntu-store vs snap-store

### DIFF
--- a/com.ubuntu.Store.desktop
+++ b/com.ubuntu.Store.desktop
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=Snap Store
+Name=Ubuntu Store
 Comment=Add, remove or update software on this computer
 Icon=${SNAP}/meta/gui/io.snapcraft.Store.png
 Exec=snap-store
 Type=Application
+OnlyShowIn=ubuntu;
 Keywords=
-NotShowIn=ubuntu;

--- a/meson.build
+++ b/meson.build
@@ -25,6 +25,7 @@ snapd_glib_dep = dependency('snapd-glib')
 soup_dep = dependency('libsoup-2.4')
 
 install_data('io.snapcraft.Store.desktop', install_dir: join_paths(get_option('datadir'), 'applications'))
+install_data('com.ubuntu.Store.desktop', install_dir: join_paths(get_option('datadir'), 'applications'))
 
 subdir('po')
 subdir('src')

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -55,6 +55,19 @@ apps:
       - wayland
       - system-observe
       - upower-observe
+  ubuntu-store:
+    command: bin/desktop-launch ${SNAP}/usr/bin/snap-store
+    desktop: usr/share/applications/com.ubuntu.Store.desktop
+    plugs:
+      - desktop
+      - desktop-legacy
+      - gsettings
+      - network
+      - snapd-control
+      - unity7
+      - wayland
+      - system-observe
+      - upower-observe
 
 parts:
   desktop-gnome-platform:


### PR DESCRIPTION
Install multiple desktop files to handle ubuntu-store on Ubuntu and snap-store everywhere else.  Build two apps in the snap, ubuntu-store and snap-store.

- [ 🗸 ] Have you followed the [guidelines for contributing](https://github.com/ubuntu/snap-store/blob/master/CONTRIBUTING.md)?
- [ 🗸 ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?

-----
